### PR TITLE
Support html messages

### DIFF
--- a/src/oxygen/robot_interface.py
+++ b/src/oxygen/robot_interface.py
@@ -257,7 +257,7 @@ class RobotResultInterface(object):
 
         for message in messages:
             if message:
-                ishtml = message[:6] == '*HTML*'
+                ishtml = message.startswith('*HTML*')
                 robot_keyword.messages.append(RobotResultMessage(message,html=ishtml))
 
         return robot_keyword

--- a/src/oxygen/robot_interface.py
+++ b/src/oxygen/robot_interface.py
@@ -257,7 +257,8 @@ class RobotResultInterface(object):
 
         for message in messages:
             if message:
-                robot_keyword.messages.append(RobotResultMessage(message))
+                ishtml = message[:6] == '*HTML*'
+                robot_keyword.messages.append(RobotResultMessage(message,html=ishtml))
 
         return robot_keyword
 

--- a/src/oxygen/robot_interface.py
+++ b/src/oxygen/robot_interface.py
@@ -258,7 +258,7 @@ class RobotResultInterface(object):
         for message in messages:
             if message:
                 ishtml = message.startswith('*HTML*')
-                robot_keyword.messages.append(RobotResultMessage(message,html=ishtml))
+                robot_keyword.messages.append(RobotResultMessage(message[6:],html=ishtml))
 
         return robot_keyword
 

--- a/tests/utest/robot_interface/test_robot_interface_basic_usage.py
+++ b/tests/utest/robot_interface/test_robot_interface_basic_usage.py
@@ -173,6 +173,7 @@ class  RobotInterfaceBasicTests(TestCase):
         for message in converted_suite.tests[1].keywords[0].messages:
             self.assertIsInstance(message, RobotMessage)
         self.assertEqual(converted[0].tests[3].keywords[0].messages[0].html, True)
+        self.assertEqual(converted[0].tests[3].keywords[0].messages[0].message, ' <a href="http://robotframework.org">Robot Framework</a>')
         self.assertEqual(converted[0].tests[2].keywords[0].messages[0].html, False)
 
     def test_result_create_wrapper_keyword_for_setup(self):

--- a/tests/utest/robot_interface/test_robot_interface_basic_usage.py
+++ b/tests/utest/robot_interface/test_robot_interface_basic_usage.py
@@ -100,6 +100,17 @@ EXAMPLE_SUITES = [{
              'name': 'case3',
              'setup': [],
              'tags': ['OXYGEN_JUNIT_UNKNOWN_EXECUTION_TIME'],
+             'teardown': []},
+            {'keywords': [{'elapsed': 0.0,
+                           'keywords': [],
+                           'messages': ['*HTML* <a href="http://robotframework.org">Robot Framework</a>'],
+                           'name': 'case3 (Execution)',
+                           'pass': False,
+                           'tags': [],
+                           'teardown': []}],
+             'name': 'case3',
+             'setup': [],
+             'tags': ['OXYGEN_JUNIT_UNKNOWN_EXECUTION_TIME'],
              'teardown': []}]
 }, {
   'name': 'suite2',
@@ -161,6 +172,8 @@ class  RobotInterfaceBasicTests(TestCase):
 
         for message in converted_suite.tests[1].keywords[0].messages:
             self.assertIsInstance(message, RobotMessage)
+        self.assertEqual(converted[0].tests[3].keywords[0].messages[0].html, True)
+        self.assertEqual(converted[0].tests[2].keywords[0].messages[0].html, False)
 
     def test_result_create_wrapper_keyword_for_setup(self):
         ret = self.iface.result.create_wrapper_keyword('My Wrapper',


### PR DESCRIPTION
Change the functionality of `spawn_robot_keyword` in `src/oxygen/robot_interface.py` to add html attribute for Message object to true if the message starts with "*HTML*" . Add test cases for both true and false  situations in `tests/utest/robot_interface/test_robot_interface_basic_usage.py` 