### PR TITLE
Strip first 6 chars only if ishtml value is true

### DIFF
--- a/src/oxygen/robot_interface.py
+++ b/src/oxygen/robot_interface.py
@@ -258,7 +258,9 @@ class RobotResultInterface(object):
         for message in messages:
             if message:
                 ishtml = message.startswith('*HTML*')
-                robot_keyword.messages.append(RobotResultMessage(message[6:],html=ishtml))
+                if ishtml:
+                  message = message[6:]  
+                robot_keyword.messages.append(RobotResultMessage(message,html=ishtml))
 
         return robot_keyword
 

--- a/tests/utest/robot_interface/test_robot_interface_basic_usage.py
+++ b/tests/utest/robot_interface/test_robot_interface_basic_usage.py
@@ -174,6 +174,8 @@ class  RobotInterfaceBasicTests(TestCase):
             self.assertIsInstance(message, RobotMessage)
         self.assertEqual(converted[0].tests[3].keywords[0].messages[0].html, True)
         self.assertEqual(converted[0].tests[3].keywords[0].messages[0].message, ' <a href="http://robotframework.org">Robot Framework</a>')
+        self.assertEqual(converted[0].tests[2].keywords[0].messages[0].message,'FAIL: Example failure message '
+                                        '(the_failure_type)' )
         self.assertEqual(converted[0].tests[2].keywords[0].messages[0].html, False)
 
     def test_result_create_wrapper_keyword_for_setup(self):


### PR DESCRIPTION
In the implementation of the first PR the first 6 chars were stripped even tough the *HTML* tag was not in the start of the message. This PR contains implementation where the chars are stripped  only when message starts with *HTML* and a unit test case which checks that an message which doesn't start with *HTML* is correct