### PR TITLE
Pin down junitparser to <2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 robotframework>=3.0.4
-junitparser>=1.2.2
+junitparser>=1.2.2,<2.0
 PyYAML>=3.13
 
 ### Dev

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='robotframework-oxygen',
       license='MIT',
       install_requires=[
            'robotframework>=3.0.4',
-           'junitparser>=1.2.2',
+           'junitparser>=1.2.2,<2.0',
            'PyYAML>=3.13'
       ],
       packages=find_packages(SRC),


### PR DESCRIPTION
Tests are failing with junitparser>2.0 because it has breaking changes from 1.x to 2.x version