### PR TITLE
Fix junitparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 robotframework>=3.0.4
-junitparser>=1.2.2,<2.0
+junitparser==2.0
 PyYAML>=3.13
 
 ### Dev

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='robotframework-oxygen',
       license='MIT',
       install_requires=[
            'robotframework>=3.0.4',
-           'junitparser>=1.2.2,<2.0',
+           'junitparser==2.0',
            'PyYAML>=3.13'
       ],
       packages=find_packages(SRC),

--- a/src/oxygen/junit.py
+++ b/src/oxygen/junit.py
@@ -24,18 +24,9 @@ class JUnitHandler(BaseHandler):
         return result_file
 
     def parse_results(self, result_file):
-        result_file = self._validate_path(result_file)
-        try:
-            xml = JUnitXml.fromfile(result_file)
-        except TypeError as e:
-            raise JUnitHandlerException(e)
+        result_file = validate_path(result_file)
+        xml = JUnitXml.fromfile(result_file)
         return self._transform_tests(xml)
-
-    def _validate_path(self, result_file):
-        try:
-            return str(validate_path(result_file).resolve())
-        except TypeError as e:
-            raise JUnitHandlerException(f'Invalid result file path: {e}')
 
     def _transform_tests(self, node):
         '''Convert the given xml object into a test suite dict

--- a/src/oxygen/utils.py
+++ b/src/oxygen/utils.py
@@ -29,7 +29,10 @@ def run_command_line(command, check_return_code=True, **env):
 
 
 def validate_path(filepath):
-    path = Path(filepath)
+    try:
+        path = Path(filepath)
+    except TypeError as e:
+        raise ResultFileIsNotAFileException(f'File "{filepath}" is not a file')
     if not path.exists():
         raise ResultFileNotFoundException(f'File "{path}" does not exits')
     if path.is_dir():

--- a/tests/utest/junit/test_basic_functionality.py
+++ b/tests/utest/junit/test_basic_functionality.py
@@ -7,7 +7,7 @@ from testfixtures import compare
 
 from oxygen.base_handler import BaseHandler
 from oxygen.junit import JUnitHandler
-from oxygen.errors import JUnitHandlerException
+from oxygen.errors import JUnitHandlerException, ResultFileIsNotAFileException
 from ..helpers import example_robot_output, get_config, RESOURCES_PATH
 
 class JUnitBasicTests(TestCase):
@@ -30,26 +30,15 @@ class JUnitBasicTests(TestCase):
         self.handler.parse_results('some/file/path.ext')
 
         mock_validate_path.assert_called_once_with('some/file/path.ext')
-        mock_junitxml.fromfile.assert_called_once_with(str(m.resolve()))
+        mock_junitxml.fromfile.assert_called_once_with(m)
         mock_transform.assert_called_once_with('some junit')
 
-    @patch('oxygen.junit.JUnitHandler._validate_path')
-    def test_JUnitXml_requires_path_to_be_string(self, mock_validate_path):
-        mock_validate_path.return_value = create_autospec(Path)
-
-        with self.assertRaises(JUnitHandlerException):
-            self.handler.parse_results('some/file/path.ext')
-
-        mock_validate_path.assert_called_once_with('some/file/path.ext')
-
-
     def test_result_file_is_not_a_string(self):
-        with self.assertRaises(JUnitHandlerException) as ex:
+        with self.assertRaises(ResultFileIsNotAFileException) as ex:
             self.handler.parse_results(None)
 
         ex = str(ex.exception)
-        self.assertIn('Invalid result file path', ex)
-        self.assertIn('not NoneType', ex)
+        self.assertIn('File "None" is not a file', ex)
 
     @patch('oxygen.utils.subprocess')
     def test_running(self, mock_subprocess):
@@ -227,6 +216,6 @@ class JUnitBasicTests(TestCase):
             }],
             'tests': []
         }
-        xml = JUnitXml.fromfile(str(RESOURCES_PATH / 'junit.xml'))
+        xml = JUnitXml.fromfile(RESOURCES_PATH / 'junit.xml')
         retval = self.handler._transform_tests(xml)
         compare(retval, expected_output)


### PR DESCRIPTION
junitparser 1.6.3 is very old dependency and it does not seem to work on modern Python. While updating the dependency, the parsing logic has changed in an unoptimal way; see more [in the reported issue](https://github.com/weiwei/junitparser/issues/115).

Thus, we are only able to go up to junitparser 2.0 in this PR.

Also, PR removes the logic that earlier version of the junitparser required, but are no longer necessary.